### PR TITLE
add runtime dependency on rackunit-lib

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -1,7 +1,8 @@
 #lang info
 
 (define version "1.0")
-(define deps '("base"))
+(define deps '("base"
+               "rackunit-lib"))
 (define build-deps
   '("racket-doc"
     "scribble-lib"))


### PR DESCRIPTION
looks like there's an unlisted runtime dependency on rackunit-lib. This change appears to satisfy `setup`.